### PR TITLE
ci: Use dedicated Static Web Apps deployment token

### DIFF
--- a/.github/workflows/fe-cd.yml
+++ b/.github/workflows/fe-cd.yml
@@ -92,34 +92,10 @@ jobs:
                       --connection-string "${{secrets.BLOB_CONNECTION_STRING}}" \
                       --overwrite
 
-            # https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-static-site-github-actions?tabs=userlevel
-            - name: Azure Login
-              uses: azure/login@v1
-              with:
-                  creds: ${{ secrets.AZURE_CREDENTIALS }}
-            - name: "Get Static Web Apps deployment token"
-              uses: azure/CLI@v2
-              with:
-                  inlineScript: |
-                      set -euo pipefail
-                      SWA_TOKEN="$(
-                        az staticwebapp secrets list \
-                          --name sticker \
-                          --resource-group custom-stickers \
-                          --query properties.apiKey \
-                          --output tsv
-                      )"
-                      test -n "${SWA_TOKEN}"
-                      echo "::add-mask::${SWA_TOKEN}"
-                      echo "SWA_DEPLOYMENT_TOKEN=${SWA_TOKEN}" >> "${GITHUB_ENV}"
             - name: "Deploy to Static Web Apps"
               uses: Azure/static-web-apps-deploy@v1
               with:
-                  azure_static_web_apps_api_token: ${{ env.SWA_DEPLOYMENT_TOKEN }}
+                  azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
                   action: upload
                   app_location: www
                   skip_app_build: true
-
-            - name: logout
-              run: az logout
-              if: always()


### PR DESCRIPTION
## Summary
- deploy Static Web Apps with the `Production` environment secret `AZURE_STATIC_WEB_APPS_API_TOKEN`
- remove the Azure Login, runtime token lookup, and logout steps from the frontend release workflow

## Why
The first production run after #440 failed because the existing `AZURE_CREDENTIALS` client secret expired (`AADSTS7000222`). Blob publishing still succeeded, but the Static Web Apps deployment was skipped. A dedicated deployment token avoids coupling this static deployment to a long-lived Azure service-principal secret.

## Validation
- encrypted deployment token stored in the GitHub `Production` environment using GitHub's public key
- workflow passes repository Prettier validation
- no Azure Login, AFD, or runtime token lookup references remain in `fe-cd.yml`

Follow-up to #440.